### PR TITLE
Homeplaces

### DIFF
--- a/src/client/actions/places.js
+++ b/src/client/actions/places.js
@@ -39,7 +39,7 @@ export const setUserPlaces = (places) => {
 
 export const getInstancePlaces = () => {
   return (dispatch) => {
-    fetch('/api/v1/places', {credentials: 'same-origin'})
+    fetch('/api/v1/places?instance=true', {credentials: 'same-origin'})
       .then((resp) => resp.json())
       .then((result) => {
         dispatch(setPlaces(result))
@@ -49,7 +49,7 @@ export const getInstancePlaces = () => {
 
 export const getUserPlaces = () => {
   return (dispatch) => {
-    fetch('/api/v1/userPlaces', {credentials: 'same-origin'})
+    fetch('/api/v1/places', {credentials: 'same-origin'})
       .then((resp) => resp.json())
       .then((result) => {
         dispatch(setUserPlaces(result))
@@ -93,7 +93,7 @@ export const saveInstancePlaces = (placeId) => {
       body: JSON.stringify(newPlaces),
       credentials: 'same-origin'
     }
-    fetch('/api/v1/places', opts)
+    fetch('/api/v1/places?instance=true', opts)
       .then(() => {
         dispatch(getInstancePlaces())
       })
@@ -113,7 +113,7 @@ export const saveUserPlaces = (placeId) => {
       body: JSON.stringify(newPlaces),
       credentials: 'same-origin'
     }
-    fetch('/api/v1/userPlaces', opts)
+    fetch('/api/v1/places', opts)
       .then(() => {
         dispatch(getUserPlaces())
       })

--- a/src/client/actions/places.js
+++ b/src/client/actions/places.js
@@ -1,7 +1,9 @@
 export const SET_WORLD = 'SET_WORLD'
 export const SET_PLACES = 'SET_PLACES'
+export const SET_USER_PLACES = 'SET_USER_PLACES'
 export const UPDATE_NEW_PLACE = 'UPDATE_NEW_PLACE'
 export const REMOVE_PLACE = 'REMOVE_PLACE'
+export const REMOVE_USER_PLACE = 'REMOVE_USER_PLACE'
 export const SAVE_PLACES = 'SAVE_PLACES'
 
 export const setWorld = (world) => {
@@ -28,7 +30,14 @@ export const setPlaces = (places) => {
   }
 }
 
-export const getPlaces = () => {
+export const setUserPlaces = (places) => {
+  return {
+    type: SET_USER_PLACES,
+    places: places
+  }
+}
+
+export const getInstancePlaces = () => {
   return (dispatch) => {
     fetch('/api/v1/places', {credentials: 'same-origin'})
       .then((resp) => resp.json())
@@ -38,10 +47,20 @@ export const getPlaces = () => {
   }
 }
 
+export const getUserPlaces = () => {
+  return (dispatch) => {
+    fetch('/api/v1/userPlaces', {credentials: 'same-origin'})
+      .then((resp) => resp.json())
+      .then((result) => {
+        dispatch(setUserPlaces(result))
+      })
+  }
+}
+
 export const updateNewPlace = (value) => {
   return {
     type: UPDATE_NEW_PLACE,
-    id: value
+    id: value,
   }
 }
 
@@ -52,9 +71,16 @@ export const removePlace = (value) => {
   }
 }
 
+export const removeUserPlace = (value) => {
+  return {
+    type: REMOVE_USER_PLACE,
+    id: value
+  }
+}
+
 /* THUNKS */
 
-export const savePlaces = (placeId) => {
+export const saveInstancePlaces = (placeId) => {
   return (dispatch, getState) => {
     const { places } = getState()
     const newPlaces = [ ...places.places ]
@@ -69,7 +95,27 @@ export const savePlaces = (placeId) => {
     }
     fetch('/api/v1/places', opts)
       .then(() => {
-        dispatch(getPlaces())
+        dispatch(getInstancePlaces())
+      })
+  }
+}
+
+export const saveUserPlaces = (placeId) => {
+  return (dispatch, getState) => {
+    const { places } = getState()
+    const newPlaces = [ ...places.userPlaces ]
+    if (placeId) {
+      newPlaces.push(placeId)
+    }
+    const opts = {
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(newPlaces),
+      credentials: 'same-origin'
+    }
+    fetch('/api/v1/userPlaces', opts)
+      .then(() => {
+        dispatch(getUserPlaces())
       })
   }
 }
@@ -77,6 +123,13 @@ export const savePlaces = (placeId) => {
 export const deletePlace = (value) => {
   return (dispatch) => {
     dispatch(removePlace(value))
-    dispatch(savePlaces())
+    dispatch(saveInstancePlaces())
+  }
+}
+
+export const deleteUserPlace = (value) => {
+  return (dispatch) => {
+    dispatch(removeUserPlace(value))
+    dispatch(saveUserPlaces())
   }
 }

--- a/src/client/components/AddPlace.js
+++ b/src/client/components/AddPlace.js
@@ -1,0 +1,74 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import Autocomplete from 'react-autocomplete'
+
+export default class AddPlace extends Component {
+
+  matchInputToTerm(input, value) {
+    return (input.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
+            input.toLowerCase().indexOf(value.toLowerCase()) !== -1)
+  }
+
+  sortPlaces(a, b, value) {
+    const aLower = a.toLowerCase()
+    const bLower = b.toLowerCase()
+    const valueLower = value.toLowerCase()
+    const queryPosA = aLower.indexOf(valueLower)
+    const queryPosB = bLower.indexOf(valueLower)
+    if (queryPosA !== queryPosB) {
+      return queryPosA - queryPosB
+    }
+    return aLower < bLower ? -1 : 1
+  }
+
+  checkPlace = () => {
+    const placeId = this.props.placeLabelToId(this.props.newPlace)
+    if (placeId) {
+      this.props.savePlaces(placeId)
+    } else {
+      // TODO: Replace with an alert component
+      alert('place not found')
+    }
+  }
+
+  render() {
+    let inputProps = {}
+    let placeDisabled = false
+
+    if (this.props.places.length >= this.props.limit) {
+      inputProps = {disabled: true}
+      placeDisabled = true
+    }
+
+    return (
+      <div>
+        <Autocomplete
+           getItemValue={(item) => item}
+           sortItems={this.sortPlaces}
+           items={Object.keys(this.props.placesByName)}
+           shouldItemRender={this.matchInputToTerm}
+           renderItem={(item, isHighlighted) =>
+             (<div style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
+               {item}
+             </div>)
+           }
+           value={this.props.newPlace}
+           onChange={(event, value) => this.props.updateNewPlace(value)}
+           onSelect={value => this.props.updateNewPlace(value)}
+           inputProps={inputProps}
+         />
+         <button onClick={ this.checkPlace } className="save" disabled={placeDisabled}>Add Place</button>
+      </div>
+    )
+  }
+}
+
+AddPlace.propTypes = {
+  limit: PropTypes.number,
+  places: PropTypes.array,
+  placesByName: PropTypes.object,
+  updateNewPlace: PropTypes.func,
+  newPlace: PropTypes.string,
+  placeLabelToId: PropTypes.func,
+  savePlaces: PropTypes.func
+}

--- a/src/client/components/AdminSettings.js
+++ b/src/client/components/AdminSettings.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import style from './Profile.css'
-import Autocomplete from 'react-autocomplete'
 import LogoUpload from './LogoUpload'
 import Keys from './Keys'
+import AddPlace from './AddPlace'
 
 export default class AdminSettings extends Component {
 
@@ -11,42 +11,7 @@ export default class AdminSettings extends Component {
     this.props.getPlaces()
   }
 
-  matchInputToTerm(input, value) {
-    return (input.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
-            input.toLowerCase().indexOf(value.toLowerCase()) !== -1)
-  }
-
-  sortPlaces(a, b, value) {
-    const aLower = a.toLowerCase()
-    const bLower = b.toLowerCase()
-    const valueLower = value.toLowerCase()
-    const queryPosA = aLower.indexOf(valueLower)
-    const queryPosB = bLower.indexOf(valueLower)
-    if (queryPosA !== queryPosB) {
-      return queryPosA - queryPosB
-    }
-    return aLower < bLower ? -1 : 1
-  }
-
-  checkPlace = () => {
-    const placeId = this.props.placeLabelToId(this.props.newPlace)
-    if (placeId) {
-      this.props.savePlaces(placeId)
-    } else {
-      // TODO: Replace with an alert component
-      alert('place not found')
-    }
-  }
-
   render() {
-    let inputProps = {}
-    let placeDisabled = false
-
-    if (this.props.places.length >= 3) {
-      inputProps = {disabled: true}
-      placeDisabled = true
-    }
-
     return (
       <div>
         <h3>Admin Settings</h3>
@@ -69,26 +34,18 @@ export default class AdminSettings extends Component {
           const place = this.props.placeIdToLabel(loc)
           return (
             <li key={i} className={ style.Place }>
-             <button className="del" onClick={()=>{this.props.deletePlace(loc)}}>x</button>{ place }
+             <button onClick={()=>{this.props.deletePlace(loc)}}>x</button>{ place }
             </li>)
         })}
         </ul>
-        <Autocomplete
-           getItemValue={(item) => item}
-           sortItems={this.sortPlaces}
-           items={Object.keys(this.props.placesByName)}
-           shouldItemRender={this.matchInputToTerm}
-           renderItem={(item, isHighlighted) =>
-             (<div style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
-               {item}
-             </div>)
-           }
-           value={this.props.newPlace}
-           onChange={(event, value) => this.props.updateNewPlace(value)}
-           onSelect={value => this.props.updateNewPlace(value)}
-           inputProps={inputProps}
-         />
-         <button onClick={ this.checkPlace } className="save" disabled={placeDisabled}>Add Place</button>
+        <AddPlace
+          limit={3}
+          places={this.props.places}
+          placesByName={this.props.placesByName}
+          updateNewPlace={this.props.updateNewPlace}
+          newPlace={this.props.newPlace}
+          placeLabelToId={this.props.placeLabelToId}
+          savePlaces={this.props.savePlaces} />
       </div>
     )
   }

--- a/src/client/components/Place.js
+++ b/src/client/components/Place.js
@@ -8,9 +8,13 @@ export default class Place extends Component {
     const trends = this.props.trends.slice(0, 10).map(trend =>
       <li key={ trend.name + trend.text }>{ trend.name } [{ trend.tweets }]</li>
     )
+    let removeBtn = null
+    if (this.props.isUserPlace) {
+      removeBtn = <button onClick={()=>{this.props.deletePlace(this.props.placeId)}}>x</button>
+    }
     return (
       <div className={styles.Place}>
-        <h3>{ this.props.name }</h3>
+        <h3>{ this.props.name } {removeBtn}</h3>
         <hr />
         <ul>
           <FlipMove
@@ -27,5 +31,8 @@ export default class Place extends Component {
 
 Place.propTypes = {
   trends: PropTypes.array,
-  name: PropTypes.string
+  name: PropTypes.string,
+  placeId: PropTypes.string,
+  isUserPlace: PropTypes.bool,
+  deletePlace: PropTypes.func
 }

--- a/src/client/components/Profile.css
+++ b/src/client/components/Profile.css
@@ -5,10 +5,3 @@
   justify-content: center;
   width: 99vw;
 }
-
-.Profile button {
-  background-color: lightgreen;
-}
-
-.Place {
-}

--- a/src/client/components/Settings.css
+++ b/src/client/components/Settings.css
@@ -10,15 +10,3 @@
 .Settings p {
   text-align: center;
 }
-
-.Settings label {
-  font-weight: bold;
-}
-
-.Settings input {
-  font-size: 18pt;
-}
-
-.Settings button {
-  background-color: lightgreen;
-}

--- a/src/client/components/Trends.js
+++ b/src/client/components/Trends.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Place from './Place'
 import '../images/dn.png'
 import styles from './Trends.css'
+import AddPlace from './AddPlace'
 
 export default class Trends extends Component {
 
@@ -20,11 +21,32 @@ export default class Trends extends Component {
   }
 
   render() {
+    let addUserTrends = null
+    if (this.props.userLoggedIn) {
+      addUserTrends = (<AddPlace
+        limit={5}
+        places={this.props.places}
+        placesByName={this.props.placesByName}
+        updateNewPlace={this.props.updateNewPlace}
+        newPlace={this.props.newPlace}
+        placeLabelToId={this.props.placeLabelToId}
+        savePlaces={this.props.savePlaces} />)
+    }
+
     return (
-      <div className={styles.Trends}>
-        {this.props.places.map(place =>
-          <Place key={place.name} trends={place.trends} name={place.name} />
-        )}
+      <div>
+        {addUserTrends}
+        <div className={styles.Trends}>
+          {this.props.places.map(place =>
+            (<Place
+              key={place.name}
+              trends={place.trends}
+              placeId={place.placeId}
+              name={place.name}
+              isUserPlace={place.user}
+              deletePlace={this.props.deletePlace} />)
+          )}
+        </div>
       </div>
     )
   }
@@ -34,4 +56,11 @@ export default class Trends extends Component {
 Trends.propTypes = {
   places: PropTypes.array,
   getPlaces: PropTypes.func,
+  userLoggedIn: PropTypes.bool,
+  placesByName: PropTypes.object,
+  updateNewPlace: PropTypes.func,
+  newPlace: PropTypes.string,
+  placeLabelToId: PropTypes.func,
+  savePlaces: PropTypes.func,
+  deletePlace: PropTypes.func
 }

--- a/src/client/components/Trends.js
+++ b/src/client/components/Trends.js
@@ -9,6 +9,7 @@ export default class Trends extends Component {
 
   componentDidMount() {
     this.props.getPlaces()
+    this.props.getUserPlaces()
     const intervalId = setInterval(this.props.getPlaces, 3000)
     this.setState({intervalId: intervalId})
   }
@@ -56,6 +57,7 @@ export default class Trends extends Component {
 Trends.propTypes = {
   places: PropTypes.array,
   getPlaces: PropTypes.func,
+  getUserPlaces: PropTypes.func,
   userLoggedIn: PropTypes.bool,
   placesByName: PropTypes.object,
   updateNewPlace: PropTypes.func,

--- a/src/client/containers/AdminSettingsForm.js
+++ b/src/client/containers/AdminSettingsForm.js
@@ -1,7 +1,7 @@
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import AdminSettings from '../components/AdminSettings'
-import { getPlaces, updateNewPlace, deletePlace, savePlaces } from '../actions/places'
+import { getInstancePlaces, updateNewPlace, deletePlace, saveInstancePlaces } from '../actions/places'
 import { updateSettings, saveSettings, postLogo } from '../actions/settings'
 
 const mapStateToProps = (state) => {
@@ -35,8 +35,8 @@ const mapStateToProps = (state) => {
 }
 
 const actions = {
-  getPlaces,
-  savePlaces,
+  getPlaces: getInstancePlaces,
+  savePlaces: saveInstancePlaces,
   saveSettings,
   postLogo
 }

--- a/src/client/containers/App.css
+++ b/src/client/containers/App.css
@@ -5,10 +5,64 @@ body {
 }
 
 button {
-  font-size: 16px;
-  padding: 10px 24px;
+  color: #1E77B6;
+  display: inline-block;
+  position: relative;
+  min-width: 64px;
+  height: 36px;
+  padding: 0 16px;
   border: none;
-  border-radius: 8px;
+  border-radius: 2px;
+  outline: solid 1px;
+  background: transparent;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: .04em;
+  line-height: 36px;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  overflow: hidden;
+  vertical-align: middle;
+  user-select: none;
+  box-sizing: border-box;
+  box-shadow: 1px 2px 3px 1px rgba(30, 119,182,0.2), 0 2px 3px 0 rgba(0,0,0,0.19);
+  -webkit-appearance: none;
+}
+
+button:disabled, button:disabled:hover {
+  cursor: default;
+  background-color: lightgrey !important;
+  color: grey !important;
+  outline: solid 1px !important;
+}
+
+button:hover {
   cursor: pointer;
+  color: #ffffff !important;
+  outline: none !important;
+  background-color: #1e77b6;
+}
+
+input[type=text] {
+    position: relative;
+    left: 80px;
+    display: inline-block;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    font-family: 'Roboto Medium', sans-serif;
+    padding: 8px 8px 8px 8px;
+    font-size: 14px;
+    width: 200px; /* should be made variable with JS */
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    background: none;
+    appearance: none;
+}
+
+input[type=text]:focus {
+  border-bottom: solid 2px #4a4a4a;
+  color: #4a4a4a;
   outline: none;
 }

--- a/src/client/containers/TrendsPage.js
+++ b/src/client/containers/TrendsPage.js
@@ -2,15 +2,39 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Trends from '../components/Trends'
 import { getPlaces } from '../actions/trends'
+import { updateNewPlace, saveUserPlaces, deleteUserPlace } from '../actions/places'
 
 const mapStateToProps = (state) => {
+  const placeLabelToId = label => {
+    if (state.places.placesByName[label]) {
+      return state.places.placesByName[label][0].id
+    }
+    return undefined
+  }
+
+  const placeIdToLabel = id => {
+    for (const place of Object.values(state.places.placesByName)) {
+      if (place[0].id === id) {
+        return place[0].name
+      }
+    }
+  }
+
   return {
-    places: state.trends.places
+    places: state.trends.places,
+    userLoggedIn: state.user.twitterScreenName !== '',
+    placesByName: state.places.placesByName || {},
+    newPlace: state.places.newPlace,
+    placeIdToLabel,
+    placeLabelToId
   }
 }
 
 const actions = {
-  getPlaces: getPlaces
+  getPlaces,
+  updateNewPlace,
+  savePlaces: saveUserPlaces,
+  deletePlace: deleteUserPlace
 }
 
 const mapDispatchToProps = (dispatch) => bindActionCreators(actions, dispatch)

--- a/src/client/containers/TrendsPage.js
+++ b/src/client/containers/TrendsPage.js
@@ -2,7 +2,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Trends from '../components/Trends'
 import { getPlaces } from '../actions/trends'
-import { updateNewPlace, saveUserPlaces, deleteUserPlace } from '../actions/places'
+import { getUserPlaces, updateNewPlace, saveUserPlaces, deleteUserPlace } from '../actions/places'
 
 const mapStateToProps = (state) => {
   const placeLabelToId = label => {
@@ -32,6 +32,7 @@ const mapStateToProps = (state) => {
 
 const actions = {
   getPlaces,
+  getUserPlaces,
   updateNewPlace,
   savePlaces: saveUserPlaces,
   deletePlace: deleteUserPlace

--- a/src/client/reducers/places.js
+++ b/src/client/reducers/places.js
@@ -1,7 +1,9 @@
-import { SET_PLACES, SET_WORLD, UPDATE_NEW_PLACE, REMOVE_PLACE } from '../actions/places'
+import { SET_PLACES, SET_WORLD, UPDATE_NEW_PLACE, REMOVE_PLACE,
+SET_USER_PLACES, REMOVE_USER_PLACE } from '../actions/places'
 
 const initialState = {
   places: [],
+  userPlaces: [],
   newPlace: ''
 }
 
@@ -40,6 +42,14 @@ export default function user(state = initialState, action) {
       }
     }
 
+    case SET_USER_PLACES: {
+      return {
+        ...state,
+        userPlaces: action.places,
+        newPlace: ''
+      }
+    }
+
     case UPDATE_NEW_PLACE: {
       return {
         ...state,
@@ -54,6 +64,16 @@ export default function user(state = initialState, action) {
       return {
         ...state,
         places
+      }
+    }
+
+    case REMOVE_USER_PLACE: {
+      const userPlaces = state.userPlaces.filter((place)=>{
+        return place !== action.id
+      })
+      return {
+        ...state,
+        userPlaces
       }
     }
 

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -74,7 +74,28 @@ app.put('/places', (req, res) => {
         db.importLatestTrendsForInstance(req.user.id)
           .then(res.json({status: 'updated'}))
       })
+  } else {
+    db.setUserPlaces(req.user.id, req.body)
+      .then(() => {
+        db.importLatestTrendsForInstance(req.user.id)
+          .then(res.json({status: 'updated'}))
+      })
   }
+})
+
+app.get('/userPlaces', (req, res) => {
+  db.getUserPlaces(req.user.id)
+    .then((places) => {
+      res.json(places)
+    })
+})
+
+app.put('/userPlaces', (req, res) => {
+  db.setUserPlaces(req.user.id, req.body)
+    .then(() => {
+      db.importLatestTrendsForUser(req.user.id)
+        .then(res.json({status: 'updated'}))
+    })
 })
 
 app.get('/world', (req, res) => {

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -61,14 +61,25 @@ app.put('/settings', (req, res) => {
 })
 
 app.get('/places', (req, res) => {
-  db.getUserPlaces('instance')
-    .then((places) => {
-      res.json(places)
-    })
+  const {instance} = req.query
+  if (instance === 'true') {
+    db.getUserPlaces('instance')
+      .then((places) => {
+        res.json(places)
+      })
+  } else {
+    if (req.user) {
+      db.getUserPlaces(req.user.id)
+        .then((places) => {
+          res.json(places)
+        })
+    }
+  }
 })
 
 app.put('/places', (req, res) => {
-  if (req.user.isSuperUser) {
+  const {instance} = req.query
+  if (instance && req.user.isSuperUser) {
     db.setInstancePlaces(req.body)
       .then(() => {
         db.importLatestTrendsForInstance(req.user.id)
@@ -77,25 +88,10 @@ app.put('/places', (req, res) => {
   } else {
     db.setUserPlaces(req.user.id, req.body)
       .then(() => {
-        db.importLatestTrendsForInstance(req.user.id)
+        db.importLatestTrendsForUser(req.user.id)
           .then(res.json({status: 'updated'}))
       })
   }
-})
-
-app.get('/userPlaces', (req, res) => {
-  db.getUserPlaces(req.user.id)
-    .then((places) => {
-      res.json(places)
-    })
-})
-
-app.put('/userPlaces', (req, res) => {
-  db.setUserPlaces(req.user.id, req.body)
-    .then(() => {
-      db.importLatestTrendsForUser(req.user.id)
-        .then(res.json({status: 'updated'}))
-    })
 })
 
 app.get('/world', (req, res) => {

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -61,19 +61,20 @@ app.put('/settings', (req, res) => {
 })
 
 app.get('/places', (req, res) => {
-  db.getUserPlaces(req.user.id)
+  db.getUserPlaces('instance')
     .then((places) => {
       res.json(places)
     })
 })
 
-
 app.put('/places', (req, res) => {
-  db.setUserPlaces(req.user.id, req.body)
-    .then(() => {
-      db.importLatestTrendsForUser(req.user.id)
-        .then(res.json({status: 'updated'}))
-    })
+  if (req.user.isSuperUser) {
+    db.setInstancePlaces(req.body)
+      .then(() => {
+        db.importLatestTrendsForInstance(req.user.id)
+          .then(res.json({status: 'updated'}))
+      })
+  }
 })
 
 app.get('/world', (req, res) => {
@@ -83,14 +84,18 @@ app.get('/world', (req, res) => {
 })
 
 app.get('/trends', (req, res) => {
-  if (req.user) {
-    db.getUserTrends(req.user.id)
-      .then((result) => {
+  db.getUserTrends('instance')
+    .then((result) => {
+      if (req.user) {
+        db.getUserTrends(req.user.id)
+          .then((userResult) => {
+            const fullResult = result.concat(userResult)
+            res.json(fullResult)
+          })
+      } else {
         res.json(result)
-      })
-  } else {
-    res.json([])
-  }
+      }
+    })
 })
 
 app.post('/logo', (req, res) => {

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -172,7 +172,7 @@ export class Database {
     }
   }
 
-  getTrends(placeId) {
+  getTrends(placeId, userId) {
     const prefixedPlaceId = this.addPrefix(placeId, 'place')
     const trendsId = this.addPrefix(prefixedPlaceId, 'trends')
     return new Promise((resolve) => {
@@ -181,7 +181,8 @@ export class Database {
           id: trendsId,
           name: place.name,
           placeId: placeId,
-          trends: []
+          trends: [],
+          user: userId !== 'instance'
         }
         this.db.zrevrangeAsync(trendsId, 0, -1, 'WITHSCORES')
           .then((result) => {
@@ -198,7 +199,7 @@ export class Database {
     return new Promise((resolve) => {
       this.getUserPlaces(userId)
         .then((placeIds) => {
-          Promise.all(placeIds.map(this.getTrends, this))
+          Promise.all(placeIds.map((placeId) => this.getTrends(placeId, userId), this))
             .then((result) => {
               resolve(result)
             })


### PR DESCRIPTION
From latest commit:

This required a few changes in both the client and server: the API endopoints for places have been changed to "places" for the whole instance and "userPlaces" for users.
Database operations also needed adjustments, but simpler: instance places are prefixed with 'instance'.

NB There are quite a few CSS issues that I haven't really tackled until we have more from Alexandra.

Closes #28