### PR TITLE
the memory limit is not a sub-key of ulimits declaration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-      mem_limit: 2g
+    mem_limit: 2g
 
   app:
     environment:


### PR DESCRIPTION
with newer versions of docker-compose this fails with a invalid literal
of 2g