### PR TITLE
SearchTerm tooltips

### DIFF
--- a/src/client/components/Explore/SearchQuery.css
+++ b/src/client/components/Explore/SearchQuery.css
@@ -4,7 +4,7 @@
   font-family: 'Roboto Medium', sans-serif;
   line-height: 34px;
   min-height: 34px;
-  width: 360px;
+  width: 400px;
   background: transparent;
   padding: 1em;
   margin-top: 20px;

--- a/src/client/components/Explore/SearchQuery.js
+++ b/src/client/components/Explore/SearchQuery.js
@@ -24,7 +24,7 @@ export default class SearchQuery extends Component {
     if (this.props.query.length === 0 && ! this.props.active) {
       placeHolder = (
         <div>
-          enter a <span className={style.SearchTerm + ' ' + style.Keyword}>&nbsp;keyword&nbsp;</span> &nbsp;
+          enter <span className={style.SearchTerm + ' ' + style.Keyword}>&nbsp;keyword&nbsp;</span> &nbsp;
           <span className={style.SearchTerm + ' ' + style.Phrase}>&nbsp;a phrase&nbsp;</span> &nbsp;
           <span className={style.SearchTerm + ' ' + style.Hashtag}>&nbsp;#hashtag&nbsp;</span> &nbsp;
           <span className={style.SearchTerm + ' ' + style.User}>&nbsp;@user&nbsp;</span>

--- a/src/client/components/Explore/SearchTerm.css
+++ b/src/client/components/Explore/SearchTerm.css
@@ -1,19 +1,16 @@
 .SearchTerm {
-  outline: none;
   cursor: pointer;
   color: rgba(0, 0, 0, 0.87);
-  border: none;
   cursor: default;
   height: 32px;
   display: inline-flex;
   outline: 0;
-  padding: 0;
-  font-size: 0.8125rem;
+  margin-right: 5px;
   box-sizing: border-box;
   transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   align-items: center;
   white-space: nowrap;
-  border-radius: 16px;
+  border-radius: 4px;
   vertical-align: middle;
   justify-content: center;
   text-decoration: none;

--- a/src/client/components/Explore/SearchTerm.js
+++ b/src/client/components/Explore/SearchTerm.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import style from './SearchTerm.css'
 import TextField from '@material-ui/core/TextField'
+import Tooltip from '@material-ui/core/Tooltip'
 
 export default class SearchTerm extends Component {
 
@@ -98,24 +99,16 @@ export default class SearchTerm extends Component {
     const cssClass = this.cssClass(type)
     const otherClassNames = this.props.className ? this.props.className : ''
     let chip = (
-      <span className={`${style.SearchTerm} ${otherClassNames}`}
+      <Tooltip title={`Explore tweets with the ${type} "${this.props.value}"`} placement="right" arrow>
+        <div className={`${style.SearchTerm} ${otherClassNames}`}
           ref={this.chip}          
           onClick={(e) => this.click(e)}          
           data-type={type}>
-          {this.props.value}</span>
+          {this.props.value}
+        </div>
+      </Tooltip>
     )
     if (this.props.onInput) {
-      // chip = (
-      //   <input className={`mdc-chip__text ${style.SearchTerm} ${otherClassNames}`}
-      //     spellCheck={false}
-      //     ref={this.chip}
-      //     data-type={type}
-      //     onKeyDown={(e) => {this.keyDown(e)}}
-      //     onChange={(e) => {this.update(e)}}
-      //     onBlur={(e) => {this.update(e)}}
-      //     value={this.props.value}
-      //     style={{width: `${this.props.value.length || 1}ch`}}/>
-      // )
       chip = (
         <TextField
           ref={this.chip}


### PR DESCRIPTION
On the trending screen if you hover over a term it will display a tooltip saying "Explore tweets with the hashtag '#example'" and related for the other search types. I also lowered the css border-radius made the terms less pill-like and a bit boxier.

After experimenting with some examples of putting the colored search term examles into the text below the search box I decided not to implement it until we've had time to design what we want that to look like.

Closes #178
